### PR TITLE
タイトル周りの見た目を調整、PC表示時のレイアウト調整

### DIFF
--- a/assets/sass/common.scss
+++ b/assets/sass/common.scss
@@ -49,5 +49,36 @@ a:focus {
 #main {
   margin-top: 2rem;
   margin-bottom: 2rem;
+  padding: 0 4vw;
 }
 
+.box{
+  h4{
+    color: #d8836e;
+  }
+  .date{
+    display: block;
+    margin-bottom: 16px;
+    font-size: 0.85em;
+    color: #666;
+  }
+  .name{
+    display: block;
+    margin-top: 8px;
+    color: rgba(#d8836e,.85);
+    font-size: 0.9em;
+    text-align: right;
+  }
+}
+@media screen and (min-width: 768px){
+  #main{
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+  }
+  .box{
+    flex-basis: calc((100% - 6 * 16px) / 3);
+    min-width: 260px;
+    margin: 0 16px 32px;
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,6 @@
         </template>
         <template v-else>
           <h4><span class="date">{{ item.date }}</span> {{ item.title }} <span class="name">by {{ item.name }}</span></h4>
-          <p>{{ item.description }}</p>
         </template>
       </div>
     </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,12 +4,12 @@
       <div class="content">
         <template v-if="item.url && item.visible">
           <h4>
-            <a :href="item.url" target="_blank" rel="noopener">{{ item.date }} {{ item.title }} by {{ item.name }}</a>
+            <a :href="item.url" target="_blank" rel="noopener"><span class="date">{{ item.date }}</span> {{ item.title }} <span class="name">by {{ item.name }}</span></a>
           </h4>
           <p>{{ item.description }}</p>
         </template>
         <template v-else>
-          <h4>{{ item.date }} {{ item.title }} by {{ item.name }}</h4>
+          <h4><span class="date">{{ item.date }}</span> {{ item.title }} <span class="name">by {{ item.name }}</span></h4>
           <p>{{ item.description }}</p>
         </template>
       </div>


### PR DESCRIPTION
タイトル部分を、日付、タイトル、担当者名ごとに改行するようにしました。
色はCampサイトのお知らせの見出しの色（だったはず）

PC時のレイアウトは基本3カラムにしました。